### PR TITLE
Add subscription metrics analytics pipeline and UI tab

### DIFF
--- a/client/analytics/index.jsx
+++ b/client/analytics/index.jsx
@@ -106,12 +106,14 @@ function AnalyticsContent() {
 	const [operationSortDirection, setOperationSortDirection] = useState('desc');
 	const [clientSortBy, setClientSortBy] = useState('hits24h');
 	const [clientSortDirection, setClientSortDirection] = useState('desc');
-	const [subscriptionSortBy, setSubscriptionSortBy] =
-		useState('estimatedSubscriptions24h');
+	const [subscriptionSortBy, setSubscriptionSortBy] = useState(
+		'estimatedSubscriptions24h'
+	);
 	const [subscriptionSortDirection, setSubscriptionSortDirection] =
 		useState('desc');
-	const [subscriptionChartMetric, setSubscriptionChartMetric] =
-		useState('estimatedSubscriptions');
+	const [subscriptionChartMetric, setSubscriptionChartMetric] = useState(
+		'estimatedSubscriptions'
+	);
 
 	const { data: fieldsData, loading: fieldsLoading } =
 		useQuery(SCHEMA_FIELDS_USAGE);
@@ -345,7 +347,10 @@ function AnalyticsContent() {
 			}
 
 			if (!bySubscription.has(subscriptionName)) {
-				bySubscription.set(subscriptionName, { title: subscriptionName, data: [] });
+				bySubscription.set(subscriptionName, {
+					title: subscriptionName,
+					data: [],
+				});
 			}
 
 			const value =
@@ -580,7 +585,8 @@ function AnalyticsContent() {
 			entry.completedSessions24h += completedSessions;
 			entry.transportedEvents24h += transportedEvents;
 			entry.weightedDurationSecSum += avgDurationSec * completedSessions;
-			entry.weightedEventsPerSessionSum += avgEventsPerSession * completedSessions;
+			entry.weightedEventsPerSessionSum +=
+				avgEventsPerSession * completedSessions;
 
 			if (bucketSec !== null && bucketSec >= last1hCutoffSec) {
 				entry.estimatedSubscriptions1h += estimatedSubscriptions;
@@ -693,10 +699,7 @@ function AnalyticsContent() {
 		setClientSortDirection(defaultDirection);
 	};
 
-	const onSubscriptionSortChange = (
-		nextSortBy,
-		defaultDirection = 'desc'
-	) => {
+	const onSubscriptionSortChange = (nextSortBy, defaultDirection = 'desc') => {
 		if (subscriptionSortBy === nextSortBy) {
 			setSubscriptionSortDirection(
 				subscriptionSortDirection === 'asc' ? 'desc' : 'asc'
@@ -801,7 +804,7 @@ function AnalyticsContent() {
 									? 'Client hits (last 24h, 1h buckets)'
 									: isSubscriptionTab
 										? 'Subscription metrics (last 24h, 1h buckets, sampled)'
-									: 'Entity hits (last 24h, 1h buckets)'}
+										: 'Entity hits (last 24h, 1h buckets)'}
 						</div>
 						{isSubscriptionTab && (
 							<label>
@@ -1493,7 +1496,9 @@ function AnalyticsContent() {
 								<th>
 									<button
 										type="button"
-										onClick={() => onSubscriptionSortChange('subscription', 'asc')}
+										onClick={() =>
+											onSubscriptionSortChange('subscription', 'asc')
+										}
 										style={{
 											cursor: 'pointer',
 											background: 'transparent',
@@ -1551,7 +1556,9 @@ function AnalyticsContent() {
 								<th>
 									<button
 										type="button"
-										onClick={() => onSubscriptionSortChange('avgSessionDurationSec')}
+										onClick={() =>
+											onSubscriptionSortChange('avgSessionDurationSec')
+										}
 										style={{
 											cursor: 'pointer',
 											background: 'transparent',
@@ -1569,7 +1576,9 @@ function AnalyticsContent() {
 								<th>
 									<button
 										type="button"
-										onClick={() => onSubscriptionSortChange('avgEventsPerSession')}
+										onClick={() =>
+											onSubscriptionSortChange('avgEventsPerSession')
+										}
 										style={{
 											cursor: 'pointer',
 											background: 'transparent',

--- a/client/analytics/index.jsx
+++ b/client/analytics/index.jsx
@@ -15,6 +15,7 @@ import {
 	SCHEMA_ENTITY_HITS,
 	SCHEMA_FIELDS_USAGE,
 	SCHEMA_OPERATION_HITS,
+	SCHEMA_SUBSCRIPTION_METRICS,
 } from '../utils/queries';
 
 const numberFormatter = new Intl.NumberFormat('en-US');
@@ -105,6 +106,12 @@ function AnalyticsContent() {
 	const [operationSortDirection, setOperationSortDirection] = useState('desc');
 	const [clientSortBy, setClientSortBy] = useState('hits24h');
 	const [clientSortDirection, setClientSortDirection] = useState('desc');
+	const [subscriptionSortBy, setSubscriptionSortBy] =
+		useState('estimatedSubscriptions24h');
+	const [subscriptionSortDirection, setSubscriptionSortDirection] =
+		useState('desc');
+	const [subscriptionChartMetric, setSubscriptionChartMetric] =
+		useState('estimatedSubscriptions');
 
 	const { data: fieldsData, loading: fieldsLoading } =
 		useQuery(SCHEMA_FIELDS_USAGE);
@@ -135,6 +142,13 @@ function AnalyticsContent() {
 			},
 		}
 	);
+	const { data: subscriptionMetricsData, loading: subscriptionMetricsLoading } =
+		useQuery(SCHEMA_SUBSCRIPTION_METRICS, {
+			variables: {
+				granularity: 'HOUR',
+				hours: 24,
+			},
+		});
 	const allPropertyRows = fieldsData?.schemaFieldsUsage || [];
 	const allEntityRows = useMemo(() => {
 		const entityMap = new Map();
@@ -161,6 +175,7 @@ function AnalyticsContent() {
 	const isPropertyTab = activeTab === 'property';
 	const isOperationTab = activeTab === 'operation';
 	const isClientTab = activeTab === 'client';
+	const isSubscriptionTab = activeTab === 'subscription';
 	const baseRows = isEntityTab ? allEntityRows : allPropertyRows;
 	const filteredRows = useMemo(() => {
 		const normalizedTerm = searchTerm.trim().toLowerCase();
@@ -310,12 +325,59 @@ function AnalyticsContent() {
 		result.sort((a, b) => a.title.localeCompare(b.title));
 		return result;
 	}, [clientHitsData, searchTerm]);
+	const subscriptionChartSeries = useMemo(() => {
+		const normalizedTerm = searchTerm.trim().toLowerCase();
+		const rows = subscriptionMetricsData?.schemaSubscriptionMetrics || [];
+		const bySubscription = new Map();
+
+		for (const row of rows) {
+			const subscriptionName = row.subscriptionName || 'anonymous';
+			if (
+				normalizedTerm &&
+				!subscriptionName.toLowerCase().includes(normalizedTerm)
+			) {
+				continue;
+			}
+
+			const time = bucketToTimestamp(row.bucket);
+			if (time === null) {
+				continue;
+			}
+
+			if (!bySubscription.has(subscriptionName)) {
+				bySubscription.set(subscriptionName, { title: subscriptionName, data: [] });
+			}
+
+			const value =
+				subscriptionChartMetric === 'avgSessionDurationSec'
+					? Number(row.avgSessionDurationSec) || 0
+					: subscriptionChartMetric === 'avgEventsPerSession'
+						? Number(row.avgEventsPerSession) || 0
+						: Number(row.estimatedSubscriptions) || 0;
+
+			bySubscription.get(subscriptionName).data.push({
+				time,
+				value,
+			});
+		}
+
+		const result = [];
+		for (const [key, series] of bySubscription.entries()) {
+			series.data.sort((a, b) => a.time - b.time);
+			result.push({ key, title: series.title, data: series.data });
+		}
+
+		result.sort((a, b) => a.title.localeCompare(b.title));
+		return result;
+	}, [subscriptionMetricsData, searchTerm, subscriptionChartMetric]);
 
 	const chartSeries = isOperationTab
 		? operationChartSeries
 		: isClientTab
 			? clientChartSeries
-			: entityChartSeries;
+			: isSubscriptionTab
+				? subscriptionChartSeries
+				: entityChartSeries;
 
 	const operationRows = useMemo(() => {
 		const byOperation = new Map();
@@ -475,12 +537,117 @@ function AnalyticsContent() {
 
 		return sortedClientRows.slice(0, parsedTopLimit);
 	}, [sortedClientRows, topLimit]);
+	const subscriptionRows = useMemo(() => {
+		const bySubscription = new Map();
+		const normalizedTerm = searchTerm.trim().toLowerCase();
+		const nowSec = Math.floor(Date.now() / 1000);
+		const last1hCutoffSec = nowSec - 60 * 60;
+		const rows = subscriptionMetricsData?.schemaSubscriptionMetrics || [];
+
+		for (const row of rows) {
+			const subscriptionName = row.subscriptionName || 'anonymous';
+			if (
+				normalizedTerm &&
+				!subscriptionName.toLowerCase().includes(normalizedTerm)
+			) {
+				continue;
+			}
+
+			const bucketSec = bucketToTimestamp(row.bucket);
+			const estimatedSubscriptions = Number(row.estimatedSubscriptions) || 0;
+			const sampledSessions = Number(row.sampledSessions) || 0;
+			const completedSessions = Number(row.completedSessions) || 0;
+			const transportedEvents = Number(row.transportedEvents) || 0;
+			const avgDurationSec = Number(row.avgSessionDurationSec) || 0;
+			const avgEventsPerSession = Number(row.avgEventsPerSession) || 0;
+
+			if (!bySubscription.has(subscriptionName)) {
+				bySubscription.set(subscriptionName, {
+					subscriptionName,
+					estimatedSubscriptions1h: 0,
+					estimatedSubscriptions24h: 0,
+					sampledSessions24h: 0,
+					completedSessions24h: 0,
+					transportedEvents24h: 0,
+					weightedDurationSecSum: 0,
+					weightedEventsPerSessionSum: 0,
+				});
+			}
+
+			const entry = bySubscription.get(subscriptionName);
+			entry.estimatedSubscriptions24h += estimatedSubscriptions;
+			entry.sampledSessions24h += sampledSessions;
+			entry.completedSessions24h += completedSessions;
+			entry.transportedEvents24h += transportedEvents;
+			entry.weightedDurationSecSum += avgDurationSec * completedSessions;
+			entry.weightedEventsPerSessionSum += avgEventsPerSession * completedSessions;
+
+			if (bucketSec !== null && bucketSec >= last1hCutoffSec) {
+				entry.estimatedSubscriptions1h += estimatedSubscriptions;
+			}
+		}
+
+		return Array.from(bySubscription.values()).map((row) => ({
+			subscriptionName: row.subscriptionName,
+			estimatedSubscriptions1h: row.estimatedSubscriptions1h,
+			estimatedSubscriptions24h: row.estimatedSubscriptions24h,
+			sampledSessions24h: row.sampledSessions24h,
+			completedSessions24h: row.completedSessions24h,
+			transportedEvents24h: row.transportedEvents24h,
+			avgSessionDurationSec:
+				row.completedSessions24h > 0
+					? row.weightedDurationSecSum / row.completedSessions24h
+					: 0,
+			avgEventsPerSession:
+				row.completedSessions24h > 0
+					? row.weightedEventsPerSessionSum / row.completedSessions24h
+					: 0,
+		}));
+	}, [subscriptionMetricsData, searchTerm]);
+
+	const sortedSubscriptionRows = useMemo(() => {
+		const rows = [...subscriptionRows];
+
+		rows.sort((rowA, rowB) => {
+			if (subscriptionSortBy === 'subscription') {
+				return subscriptionSortDirection === 'asc'
+					? rowA.subscriptionName.localeCompare(rowB.subscriptionName)
+					: rowB.subscriptionName.localeCompare(rowA.subscriptionName);
+			}
+
+			const valueA = Number(rowA[subscriptionSortBy]) || 0;
+			const valueB = Number(rowB[subscriptionSortBy]) || 0;
+			if (valueA === valueB) {
+				return rowA.subscriptionName.localeCompare(rowB.subscriptionName);
+			}
+
+			return subscriptionSortDirection === 'asc'
+				? valueA - valueB
+				: valueB - valueA;
+		});
+
+		return rows;
+	}, [subscriptionRows, subscriptionSortBy, subscriptionSortDirection]);
+
+	const visibleSubscriptionRows = useMemo(() => {
+		if (topLimit === 'all') {
+			return sortedSubscriptionRows;
+		}
+
+		const parsedTopLimit = Number(topLimit);
+		if (!parsedTopLimit || parsedTopLimit <= 0) {
+			return sortedSubscriptionRows;
+		}
+
+		return sortedSubscriptionRows.slice(0, parsedTopLimit);
+	}, [sortedSubscriptionRows, topLimit]);
 
 	if (
 		fieldsLoading ||
 		entityHitsLoading ||
 		operationHitsLoading ||
-		clientHitsLoading
+		clientHitsLoading ||
+		subscriptionMetricsLoading
 	) {
 		return <SpinnerCenter />;
 	}
@@ -488,7 +655,8 @@ function AnalyticsContent() {
 	if (
 		!allPropertyRows.length &&
 		!(operationHitsData?.schemaOperationHits || []).length &&
-		!(clientHitsData?.schemaClientHits || []).length
+		!(clientHitsData?.schemaClientHits || []).length &&
+		!(subscriptionMetricsData?.schemaSubscriptionMetrics || []).length
 	) {
 		return <Info>No usage data logged yet</Info>;
 	}
@@ -525,8 +693,23 @@ function AnalyticsContent() {
 		setClientSortDirection(defaultDirection);
 	};
 
+	const onSubscriptionSortChange = (
+		nextSortBy,
+		defaultDirection = 'desc'
+	) => {
+		if (subscriptionSortBy === nextSortBy) {
+			setSubscriptionSortDirection(
+				subscriptionSortDirection === 'asc' ? 'desc' : 'asc'
+			);
+			return;
+		}
+
+		setSubscriptionSortBy(nextSortBy);
+		setSubscriptionSortDirection(defaultDirection);
+	};
+
 	return (
-		<div style={{ padding: '16px' }}>
+		<div>
 			<div style={{ display: 'flex', gap: '8px', marginBottom: '12px' }}>
 				<button
 					type="button"
@@ -580,6 +763,19 @@ function AnalyticsContent() {
 				>
 					Operations
 				</button>
+				<button
+					type="button"
+					onClick={() => setActiveTab('subscription')}
+					style={{
+						padding: '8px 12px',
+						border: '1px solid #DDDDDD',
+						background: isSubscriptionTab ? '#F0F6FF' : '#FFFFFF',
+						cursor: 'pointer',
+						fontWeight: isSubscriptionTab ? 'bold' : 'normal',
+					}}
+				>
+					Subscriptions
+				</button>
 			</div>
 
 			{!isPropertyTab && (
@@ -603,8 +799,32 @@ function AnalyticsContent() {
 								? 'Operation hits (last 24h, 1h buckets)'
 								: isClientTab
 									? 'Client hits (last 24h, 1h buckets)'
+									: isSubscriptionTab
+										? 'Subscription metrics (last 24h, 1h buckets, sampled)'
 									: 'Entity hits (last 24h, 1h buckets)'}
 						</div>
+						{isSubscriptionTab && (
+							<label>
+								Metric
+								<select
+									value={subscriptionChartMetric}
+									onChange={(event) =>
+										setSubscriptionChartMetric(event.target.value)
+									}
+									style={{ marginLeft: '8px' }}
+								>
+									<option value="estimatedSubscriptions">
+										Estimated subscriptions
+									</option>
+									<option value="avgSessionDurationSec">
+										Avg duration (sec)
+									</option>
+									<option value="avgEventsPerSession">
+										Avg events/session
+									</option>
+								</select>
+							</label>
+						)}
 					</div>
 					{chartSeries.length === 0 ? (
 						<Info>No chart data for selected filters</Info>
@@ -821,6 +1041,114 @@ function AnalyticsContent() {
 				</div>
 			)}
 
+			{isSubscriptionTab && (
+				<div
+					style={{
+						display: 'flex',
+						gap: '12px',
+						marginBottom: '16px',
+						flexWrap: 'wrap',
+					}}
+				>
+					<div
+						style={{
+							border: '1px solid #EEEEEE',
+							padding: '12px 16px',
+							minWidth: '180px',
+						}}
+					>
+						<div>Subscriptions (shown)</div>
+						<strong>
+							{numberFormatter.format(visibleSubscriptionRows.length)}
+						</strong>
+					</div>
+					<div
+						style={{
+							border: '1px solid #EEEEEE',
+							padding: '12px 16px',
+							minWidth: '180px',
+						}}
+					>
+						<div>Estimated subscriptions (1h)</div>
+						<strong>
+							{numberFormatter.format(
+								Math.round(
+									visibleSubscriptionRows.reduce(
+										(sum, row) => sum + row.estimatedSubscriptions1h,
+										0
+									)
+								)
+							)}
+						</strong>
+					</div>
+					<div
+						style={{
+							border: '1px solid #EEEEEE',
+							padding: '12px 16px',
+							minWidth: '180px',
+						}}
+					>
+						<div>Estimated subscriptions (24h)</div>
+						<strong>
+							{numberFormatter.format(
+								Math.round(
+									visibleSubscriptionRows.reduce(
+										(sum, row) => sum + row.estimatedSubscriptions24h,
+										0
+									)
+								)
+							)}
+						</strong>
+					</div>
+					<div
+						style={{
+							border: '1px solid #EEEEEE',
+							padding: '12px 16px',
+							minWidth: '180px',
+						}}
+					>
+						<div>Avg duration (sec)</div>
+						<strong>
+							{numberFormatter.format(
+								visibleSubscriptionRows.length
+									? Math.round(
+											(visibleSubscriptionRows.reduce(
+												(sum, row) => sum + row.avgSessionDurationSec,
+												0
+											) /
+												visibleSubscriptionRows.length) *
+												100
+										) / 100
+									: 0
+							)}
+						</strong>
+					</div>
+					<div
+						style={{
+							border: '1px solid #EEEEEE',
+							padding: '12px 16px',
+							minWidth: '180px',
+						}}
+					>
+						<div>Avg events/session</div>
+						<strong>
+							{numberFormatter.format(
+								visibleSubscriptionRows.length
+									? Math.round(
+											(visibleSubscriptionRows.reduce(
+												(sum, row) => sum + row.avgEventsPerSession,
+												0
+											) /
+												visibleSubscriptionRows.length) *
+												100
+										) / 100
+									: 0
+							)}
+						</strong>
+					</div>
+				</div>
+			)}
+
 			<div
 				style={{
 					display: 'flex',
@@ -837,9 +1165,11 @@ function AnalyticsContent() {
 							? 'Search operation'
 							: isClientTab
 								? 'Search client@version'
-								: isEntityTab
-									? 'Search entity'
-									: 'Search entity.field'
+								: isSubscriptionTab
+									? 'Search subscription'
+									: isEntityTab
+										? 'Search entity'
+										: 'Search entity.field'
 					}
 					value={searchTerm}
 					onChange={(event) => setSearchTerm(event.target.value)}
@@ -1151,6 +1481,145 @@ function AnalyticsContent() {
 					</table>
 					{!visibleClientRows.length && (
 						<Info>No client versions match current filters</Info>
+					)}
+				</div>
+			)}
+
+			{isSubscriptionTab && (
+				<div style={{ width: '100%' }}>
+					<table width="100%">
+						<thead>
+							<tr>
+								<th>
+									<button
+										type="button"
+										onClick={() => onSubscriptionSortChange('subscription', 'asc')}
+										style={{
+											cursor: 'pointer',
+											background: 'transparent',
+											border: 0,
+											padding: 0,
+											fontWeight: 'bold',
+										}}
+									>
+										Subscription{' '}
+										{subscriptionSortBy === 'subscription'
+											? `(${subscriptionSortDirection})`
+											: ''}
+									</button>
+								</th>
+								<th>
+									<button
+										type="button"
+										onClick={() =>
+											onSubscriptionSortChange('estimatedSubscriptions1h')
+										}
+										style={{
+											cursor: 'pointer',
+											background: 'transparent',
+											border: 0,
+											padding: 0,
+											fontWeight: 'bold',
+										}}
+									>
+										Estimated (1h){' '}
+										{subscriptionSortBy === 'estimatedSubscriptions1h'
+											? `(${subscriptionSortDirection})`
+											: ''}
+									</button>
+								</th>
+								<th>
+									<button
+										type="button"
+										onClick={() =>
+											onSubscriptionSortChange('estimatedSubscriptions24h')
+										}
+										style={{
+											cursor: 'pointer',
+											background: 'transparent',
+											border: 0,
+											padding: 0,
+											fontWeight: 'bold',
+										}}
+									>
+										Estimated (24h){' '}
+										{subscriptionSortBy === 'estimatedSubscriptions24h'
+											? `(${subscriptionSortDirection})`
+											: ''}
+									</button>
+								</th>
+								<th>
+									<button
+										type="button"
+										onClick={() => onSubscriptionSortChange('avgSessionDurationSec')}
+										style={{
+											cursor: 'pointer',
+											background: 'transparent',
+											border: 0,
+											padding: 0,
+											fontWeight: 'bold',
+										}}
+									>
+										Avg duration (sec){' '}
+										{subscriptionSortBy === 'avgSessionDurationSec'
+											? `(${subscriptionSortDirection})`
+											: ''}
+									</button>
+								</th>
+								<th>
+									<button
+										type="button"
+										onClick={() => onSubscriptionSortChange('avgEventsPerSession')}
+										style={{
+											cursor: 'pointer',
+											background: 'transparent',
+											border: 0,
+											padding: 0,
+											fontWeight: 'bold',
+										}}
+									>
+										Avg events/session{' '}
+										{subscriptionSortBy === 'avgEventsPerSession'
+											? `(${subscriptionSortDirection})`
+											: ''}
+									</button>
+								</th>
+								<th>Sampled sessions (24h)</th>
+							</tr>
+						</thead>
+						<tbody>
+							{visibleSubscriptionRows.map((row) => (
+								<tr key={row.subscriptionName}>
+									<td>{row.subscriptionName}</td>
+									<td align="center">
+										{numberFormatter.format(
+											Math.round(row.estimatedSubscriptions1h)
+										)}
+									</td>
+									<td align="center">
+										{numberFormatter.format(
+											Math.round(row.estimatedSubscriptions24h)
+										)}
+									</td>
+									<td align="center">
+										{numberFormatter.format(
+											Math.round(row.avgSessionDurationSec * 100) / 100
+										)}
+									</td>
+									<td align="center">
+										{numberFormatter.format(
+											Math.round(row.avgEventsPerSession * 100) / 100
+										)}
+									</td>
+									<td align="center">
+										{numberFormatter.format(row.sampledSessions24h)}
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+					{!visibleSubscriptionRows.length && (
+						<Info>No subscriptions match current filters</Info>
 					)}
 				</div>
 			)}

--- a/client/components/Main.jsx
+++ b/client/components/Main.jsx
@@ -25,42 +25,49 @@ import Logs from '../logs';
 const UITabs = [
 	{
 		Title: <span>Schema</span>,
+		pageTitle: 'Schema',
 		icon: <SchemaIcon />,
 		href: '/schema',
 		component: SupergraphSchema,
 	},
 	{
 		Title: <ServicesTab />,
+		pageTitle: 'Services',
 		icon: <ServicesIcon />,
 		href: '/services',
 		component: Services,
 	},
 	{
 		Title: <span>Analytics</span>,
+		pageTitle: 'Analytics',
 		icon: <AnalyticsIcon />,
 		href: '/analytics',
 		component: Analytics,
 	},
 	{
 		Title: <span>Subscriptions</span>,
+		pageTitle: 'Subscriptions',
 		icon: <SubscriptionsIcon />,
 		href: '/subscriptions',
 		component: Subscriptions,
 	},
 	{
 		Title: <PersistedQueriesTab />,
+		pageTitle: 'Persisted Queries',
 		icon: <PersistedQueriesIcon />,
 		href: '/persisted-queries',
 		component: PersistedQueries,
 	},
 	{
 		Title: <span>Change Log</span>,
+		pageTitle: 'Change Log',
 		icon: <ChangeLogIcon />,
 		href: '/changes',
 		component: SchemaChangeLog,
 	},
 	{
 		Title: <span>Logs</span>,
+		pageTitle: 'Logs',
 		icon: <LogsIcon />,
 		href: '/logs',
 		component: Logs,
@@ -103,7 +110,10 @@ const Main = () => {
 							path={`${tab.href}*`}
 							render={() => (
 								<TabPanel key={index} index={index} value={selectedTab}>
-									<tab.component />
+									<div className="registry-page-shell">
+										<h1 className="registry-page-title">{tab.pageTitle}</h1>
+										<tab.component />
+									</div>
 								</TabPanel>
 							)}
 						/>

--- a/client/components/TopMenu.jsx
+++ b/client/components/TopMenu.jsx
@@ -43,49 +43,64 @@ export default function TopMenu({ UITabs, selectedTab, handleChange }) {
 				value={selectedTab}
 				onChange={handleChange}
 				aria-label="Schema registry sections"
+				TabIndicatorProps={{ style: { display: 'none' } }}
 				style={{ flexGrow: 1, width: '100%' }}
 			>
-				{UITabs.map((tab, i) => (
-					<Tab
-						key={i}
-						onClick={() => history.push(tab.href)}
-						label={
-							<span
-								style={{
-									width: '100%',
-									textAlign: 'left',
-									display: 'inline-flex',
-									alignItems: 'center',
-									gap: 10,
-								}}
-							>
+				{UITabs.map((tab, i) => {
+					const isSelected = selectedTab === i;
+
+					return (
+						<Tab
+							key={i}
+							onClick={() => history.push(tab.href)}
+							label={
 								<span
 									style={{
-										width: 18,
-										height: 18,
+										width: '100%',
+										textAlign: 'left',
 										display: 'inline-flex',
 										alignItems: 'center',
-										justifyContent: 'center',
+										gap: 10,
 									}}
 								>
-									{tab.icon}
+									<span
+										style={{
+											width: 18,
+											height: 18,
+											display: 'inline-flex',
+											alignItems: 'center',
+											justifyContent: 'center',
+										}}
+									>
+										{tab.icon}
+									</span>
+									<span>{tab.Title}</span>
 								</span>
-								<span>{tab.Title}</span>
-							</span>
-						}
-						style={{
-							width: '100%',
-							maxWidth: 'none',
-							alignItems: 'flex-start',
-							justifyContent: 'flex-start',
-							minHeight: 44,
-							paddingLeft: 16,
-							paddingRight: 16,
-							textTransform: 'none',
-							textAlign: 'left',
-						}}
-					/>
-				))}
+							}
+							style={{
+								width: 'calc(100% - 16px)',
+								maxWidth: 'none',
+								alignItems: 'flex-start',
+								justifyContent: 'flex-start',
+								minHeight: 44,
+								margin: '4px 8px',
+								borderRadius: 8,
+								paddingLeft: 16,
+								paddingRight: 16,
+								textTransform: 'none',
+								textAlign: 'left',
+								color: '#ffffff',
+								fontWeight: isSelected ? 700 : 500,
+								backgroundColor: isSelected
+									? 'rgba(255, 255, 255, 0.26)'
+									: 'transparent',
+								border: isSelected
+									? '1px solid rgba(255, 255, 255, 0.5)'
+									: '1px solid transparent',
+							}}
+						/>
+					);
+				})}
 			</Tabs>
 		</AppBar>
 	);

--- a/client/style.css
+++ b/client/style.css
@@ -29,6 +29,24 @@ body {
 	overflow: auto;
 }
 
+.registry-page-shell {
+	padding: 12px 18px 24px;
+}
+
+.registry-page-title {
+	margin: 0 0 14px;
+	font-size: 24px;
+	font-weight: 700;
+	color: #1f2937;
+}
+
+.registry-muted-note {
+	margin: 0 0 12px;
+	color: #6b7280;
+	font-size: 14px;
+	line-height: 1.45;
+}
+
 @media (max-width: 900px) {
 	.registry-layout {
 		flex-direction: column;

--- a/client/subscriptions/index.jsx
+++ b/client/subscriptions/index.jsx
@@ -157,10 +157,10 @@ export default function Subscriptions() {
 
 	return (
 		<div>
-			<Info>
+			<p className="registry-muted-note">
 				Subscription catalog from event-stream services. This list is separate
 				from federated schema composition.
-			</Info>
+			</p>
 
 			<h3 style={{ margin: '8px 0' }}>Sources</h3>
 			<table
@@ -281,7 +281,9 @@ export default function Subscriptions() {
 					<SourceCodeWithHighlight code={selectedPayloadSdl} />
 				</div>
 			) : (
-				<Info>Click a payload type to preview SDL.</Info>
+				<p className="registry-muted-note" style={{ marginTop: 0 }}>
+					Click a payload type to preview SDL.
+				</p>
 			)}
 		</div>
 	);

--- a/client/supergraph/index.jsx
+++ b/client/supergraph/index.jsx
@@ -51,7 +51,7 @@ export default function SupergraphSchema() {
 	}
 
 	return (
-		<div style={{ padding: '12px 18px' }}>
+		<div>
 			<Tabs
 				value={tabValue}
 				onChange={(_, nextTabValue) => setTabValue(nextTabValue)}

--- a/client/utils/queries.js
+++ b/client/utils/queries.js
@@ -163,6 +163,24 @@ export const SCHEMA_CLIENT_HITS = gql`
 	}
 `;
 
+export const SCHEMA_SUBSCRIPTION_METRICS = gql`
+	query getSchemaSubscriptionMetrics(
+		$granularity: UsageGranularity
+		$hours: Int
+	) {
+		schemaSubscriptionMetrics(granularity: $granularity, hours: $hours) {
+			subscriptionName
+			bucket
+			sampledSessions
+			completedSessions
+			estimatedSubscriptions
+			transportedEvents
+			avgSessionDurationSec
+			avgEventsPerSession
+		}
+	}
+`;
+
 export const SCHEMA_TOP_OPERATIONS = gql`
 	query getSchemaTopOperations($hours: Int, $limit: Int) {
 		schemaTopOperations(hours: $hours, limit: $limit) {

--- a/migrations/20260310221000_add_subscription_metrics_hourly.sql
+++ b/migrations/20260310221000_add_subscription_metrics_hourly.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS subscription_metric_hourly (
+    subscription_name VARCHAR(255) NOT NULL,
+    hour TIMESTAMP NOT NULL,
+    sampled_sessions INTEGER NOT NULL DEFAULT 0,
+    completed_sessions INTEGER NOT NULL DEFAULT 0,
+    estimated_subscriptions DOUBLE PRECISION NOT NULL DEFAULT 0,
+    transported_events BIGINT NOT NULL DEFAULT 0,
+    session_duration_ms BIGINT NOT NULL DEFAULT 0,
+    updated_time TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (subscription_name, hour)
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscription_metric_hourly_hour
+    ON subscription_metric_hourly(hour DESC);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "packageManager": "pnpm@10.29.2",
   "scripts": {
-    "prepare": "sh ./setup-hooks.sh",
+    "prepare": "sh -c 'if [ -f ./setup-hooks.sh ]; then sh ./setup-hooks.sh; else echo \"setup-hooks.sh not present, skipping hooks setup\"; fi'",
     "develop": "DB_HOST=localhost DB_PORT=6000 REDIS_HOST=localhost REDIS_PORT=6004 PORT=6001 NODE_ENV=development ts-node-dev --respawn --transpile-only src/schema-registry.ts --watch src --inspect",
     "develop-frontend": "vite",
     "develop-worker": "DB_HOST=localhost DB_PORT=6000 REDIS_HOST=localhost REDIS_PORT=6004 PORT=6001 NODE_ENV=development ts-node-dev --respawn --transpile-only src/worker/index.ts --watch src --inspect",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "packageManager": "pnpm@10.29.2",
   "scripts": {
+    "prepare": "sh ./setup-hooks.sh",
     "develop": "DB_HOST=localhost DB_PORT=6000 REDIS_HOST=localhost REDIS_PORT=6004 PORT=6001 NODE_ENV=development ts-node-dev --respawn --transpile-only src/schema-registry.ts --watch src --inspect",
     "develop-frontend": "vite",
     "develop-worker": "DB_HOST=localhost DB_PORT=6000 REDIS_HOST=localhost REDIS_PORT=6004 PORT=6001 NODE_ENV=development ts-node-dev --respawn --transpile-only src/worker/index.ts --watch src --inspect",
@@ -49,12 +50,6 @@
   "keywords": [
     "graphql"
   ],
-  "husky": {
-    "hooks": {
-      "pre-commit": "pnpm run format",
-      "pre-push": "pnpm run lint:ci"
-    }
-  },
   "license": "MIT",
   "private": false,
   "dependencies": {

--- a/setup-hooks.sh
+++ b/setup-hooks.sh
@@ -11,6 +11,16 @@ if [ ! -d "$HOOKS_DIR" ]; then
   exit 1
 fi
 
+if ! command -v git >/dev/null 2>&1; then
+  echo "Git is not available, skipping hook setup."
+  exit 0
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Not inside a git work tree, skipping hook setup."
+  exit 0
+fi
+
 chmod +x "$HOOKS_DIR"/*
 git config core.hooksPath .githooks
 

--- a/src/database/subscription_metrics.ts
+++ b/src/database/subscription_metrics.ts
@@ -1,0 +1,238 @@
+import { find } from 'lodash';
+
+import { connection, transact } from './index';
+import { rowsFromRaw } from './raw-results';
+import redis from '../redis';
+import { logger } from '../logger';
+
+type SubscriptionMetricCacheRow = {
+	subscriptionName: string;
+	hour: string;
+	sampledSessions: number;
+	completedSessions: number;
+	estimatedSubscriptions: number;
+	transportedEvents: number;
+	sessionDurationMs: number;
+};
+
+const subscriptionMetricModel = {
+	timer: null,
+	internalCache: [] as SubscriptionMetricCacheRow[],
+	SAVE_INTERVAL_MS: 30 * 1000,
+	DELETE_INTERVAL_MS: 5 * 60 * 1000,
+	MAX_RETENTION_DAYS: 5,
+
+	init: function () {
+		logger.info('starting subscription metric memory-to-db synchronizer');
+		subscriptionMetricModel.timer = setInterval(
+			subscriptionMetricModel.syncToDb,
+			subscriptionMetricModel.SAVE_INTERVAL_MS
+		);
+
+		logger.info('starting subscription metric periodic cleanup from db');
+		setInterval(async () => {
+			const now = Date.now();
+			await subscriptionMetricModel.deleteOlderThan(
+				now - subscriptionMetricModel.MAX_RETENTION_DAYS * 24 * 3600 * 1000
+			);
+		}, subscriptionMetricModel.DELETE_INTERVAL_MS);
+	},
+
+	syncToDb: async function () {
+		for (const row of subscriptionMetricModel.internalCache) {
+			await subscriptionMetricModel.storeInDb(row);
+		}
+
+		subscriptionMetricModel.internalCache = [];
+	},
+
+	add: async function ({
+		subscriptionName,
+		hour,
+		sampledSessions = 0,
+		completedSessions = 0,
+		estimatedSubscriptions = 0,
+		transportedEvents = 0,
+		sessionDurationMs = 0,
+	}: {
+		subscriptionName: string;
+		hour: string;
+		sampledSessions?: number;
+		completedSessions?: number;
+		estimatedSubscriptions?: number;
+		transportedEvents?: number;
+		sessionDurationMs?: number;
+	}) {
+		const row = find(subscriptionMetricModel.internalCache, {
+			subscriptionName,
+			hour,
+		});
+
+		if (row) {
+			row.sampledSessions += sampledSessions;
+			row.completedSessions += completedSessions;
+			row.estimatedSubscriptions += estimatedSubscriptions;
+			row.transportedEvents += transportedEvents;
+			row.sessionDurationMs += sessionDurationMs;
+			return;
+		}
+
+		subscriptionMetricModel.internalCache.push({
+			subscriptionName,
+			hour,
+			sampledSessions,
+			completedSessions,
+			estimatedSubscriptions,
+			transportedEvents,
+			sessionDurationMs,
+		});
+	},
+
+	storeInDb: async function ({
+		subscriptionName,
+		hour,
+		sampledSessions,
+		completedSessions,
+		estimatedSubscriptions,
+		transportedEvents,
+		sessionDurationMs,
+	}: SubscriptionMetricCacheRow) {
+		await transact(async (trx) => {
+			const existingCount = (
+				await trx('subscription_metric_hourly')
+					.count('subscription_name', { as: 'cnt' })
+					.where({
+						subscription_name: subscriptionName,
+						hour,
+					})
+			)[0].cnt;
+
+			if (existingCount > 0) {
+				await trx('subscription_metric_hourly')
+					.where({
+						subscription_name: subscriptionName,
+						hour,
+					})
+					.update({
+						sampled_sessions: trx.raw('sampled_sessions + ?', [sampledSessions]),
+						completed_sessions: trx.raw('completed_sessions + ?', [
+							completedSessions,
+						]),
+						estimated_subscriptions: trx.raw('estimated_subscriptions + ?', [
+							estimatedSubscriptions,
+						]),
+						transported_events: trx.raw('transported_events + ?', [
+							transportedEvents,
+						]),
+						session_duration_ms: trx.raw('session_duration_ms + ?', [
+							sessionDurationMs,
+						]),
+						updated_time: new Date(),
+					});
+			} else {
+				await trx('subscription_metric_hourly')
+					.insert({
+						subscription_name: subscriptionName,
+						hour,
+						sampled_sessions: sampledSessions,
+						completed_sessions: completedSessions,
+						estimated_subscriptions: estimatedSubscriptions,
+						transported_events: transportedEvents,
+						session_duration_ms: sessionDurationMs,
+						updated_time: new Date(),
+					})
+					.onConflict(['subscription_name', 'hour'])
+					.ignore();
+			}
+		});
+	},
+
+	getHits: async function ({
+		granularity = 'HOUR',
+		hours = 24,
+	}: {
+		granularity?: 'DAY' | 'HOUR';
+		hours?: number;
+	}) {
+		const sanitizedHours = Number.isFinite(hours)
+			? Math.max(1, Math.min(24 * 30, Math.floor(hours)))
+			: 24;
+
+		const cacheKey = `subscription_metrics.${granularity}.${sanitizedHours}`;
+		const cachedResults = await redis.get(cacheKey);
+		if (cachedResults) {
+			return JSON.parse(cachedResults);
+		}
+
+		const results =
+			granularity === 'HOUR'
+				? await connection.raw(
+						`SELECT subscription_name as "subscriptionName",
+								TO_CHAR(hour, 'YYYY-MM-DD"T"HH24:00:00"Z"') as bucket,
+								SUM(sampled_sessions)::int as "sampledSessions",
+								SUM(completed_sessions)::int as "completedSessions",
+								ROUND(SUM(estimated_subscriptions)::numeric, 2)::float as "estimatedSubscriptions",
+								SUM(transported_events)::int as "transportedEvents",
+								ROUND(
+									CASE WHEN SUM(completed_sessions) > 0
+										THEN (SUM(session_duration_ms)::numeric / SUM(completed_sessions)) / 1000
+										ELSE 0
+									END,
+									2
+								)::float as "avgSessionDurationSec",
+								ROUND(
+									CASE WHEN SUM(completed_sessions) > 0
+										THEN SUM(transported_events)::numeric / SUM(completed_sessions)
+										ELSE 0
+									END,
+									2
+								)::float as "avgEventsPerSession"
+						 FROM subscription_metric_hourly
+						 WHERE hour >= NOW() - (? || ' hour')::interval
+						 GROUP BY subscription_name, hour
+						 ORDER BY hour, subscription_name`,
+						[sanitizedHours]
+					)
+				: await connection.raw(
+						`SELECT subscription_name as "subscriptionName",
+								TO_CHAR(DATE_TRUNC('day', hour), 'YYYY-MM-DD') as bucket,
+								SUM(sampled_sessions)::int as "sampledSessions",
+								SUM(completed_sessions)::int as "completedSessions",
+								ROUND(SUM(estimated_subscriptions)::numeric, 2)::float as "estimatedSubscriptions",
+								SUM(transported_events)::int as "transportedEvents",
+								ROUND(
+									CASE WHEN SUM(completed_sessions) > 0
+										THEN (SUM(session_duration_ms)::numeric / SUM(completed_sessions)) / 1000
+										ELSE 0
+									END,
+									2
+								)::float as "avgSessionDurationSec",
+								ROUND(
+									CASE WHEN SUM(completed_sessions) > 0
+										THEN SUM(transported_events)::numeric / SUM(completed_sessions)
+										ELSE 0
+									END,
+									2
+								)::float as "avgEventsPerSession"
+						 FROM subscription_metric_hourly
+						 WHERE hour >= NOW() - (? || ' hour')::interval
+						 GROUP BY subscription_name, DATE_TRUNC('day', hour)
+						 ORDER BY DATE_TRUNC('day', hour), subscription_name`,
+						[sanitizedHours]
+					);
+
+		const rows = rowsFromRaw(results);
+		await redis.set(cacheKey, JSON.stringify(rows), 60);
+		return rows;
+	},
+
+	deleteOlderThan: async function (timestampMs: number) {
+		const hourFormatted = new Date(timestampMs).toISOString();
+		await connection.raw(
+			`DELETE FROM subscription_metric_hourly WHERE hour < ?`,
+			[hourFormatted]
+		);
+	},
+};
+
+export default subscriptionMetricModel;

--- a/src/database/subscription_metrics.ts
+++ b/src/database/subscription_metrics.ts
@@ -114,7 +114,9 @@ const subscriptionMetricModel = {
 						hour,
 					})
 					.update({
-						sampled_sessions: trx.raw('sampled_sessions + ?', [sampledSessions]),
+						sampled_sessions: trx.raw('sampled_sessions + ?', [
+							sampledSessions,
+						]),
 						completed_sessions: trx.raw('completed_sessions + ?', [
 							completedSessions,
 						]),

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -16,6 +16,7 @@ import servicesModel from '../database/services';
 
 import schemaHit from '../database/schema_hits';
 import operationHit from '../database/operation_hits';
+import subscriptionMetrics from '../database/subscription_metrics';
 import clientsModel from '../database/clients';
 import subscriptionsModel from '../database/subscriptions';
 
@@ -72,6 +73,8 @@ export default {
 			await schemaHit.getClientHits({ granularity, hours }),
 		schemaOperationHits: async (_, { granularity, hours }) =>
 			await operationHit.getHits({ granularity, hours }),
+		schemaSubscriptionMetrics: async (_, { granularity, hours }) =>
+			await subscriptionMetrics.getHits({ granularity, hours }),
 		schemaTopOperations: async (_, { hours, limit }) =>
 			await operationHit.getTopOperations({ hours, limit }),
 

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -38,6 +38,10 @@ export default gql`
 			granularity: UsageGranularity = HOUR
 			hours: Int = 24
 		): [SchemaOperationHit]
+		schemaSubscriptionMetrics(
+			granularity: UsageGranularity = HOUR
+			hours: Int = 24
+		): [SchemaSubscriptionMetricHit]
 		schemaTopOperations(hours: Int = 24, limit: Int = 20): [SchemaOperationSummary]
 
 		persistedQueries(
@@ -158,6 +162,17 @@ export default gql`
 		operationName: String!
 		operationType: String!
 		hits: Int!
+	}
+
+	type SchemaSubscriptionMetricHit {
+		subscriptionName: String!
+		bucket: String!
+		sampledSessions: Int!
+		completedSessions: Int!
+		estimatedSubscriptions: Float!
+		transportedEvents: Int!
+		avgSessionDurationSec: Float!
+		avgEventsPerSession: Float!
 	}
 
 	type Container {

--- a/src/redis/index.ts
+++ b/src/redis/index.ts
@@ -4,11 +4,13 @@ import { logger } from '../logger';
 import diplomat from '../diplomat';
 
 const DEFAULT_TTL = 24 * 3600;
-const GET_TIMEOUT_MS = 30;
-const SET_TIMEOUT_MS = 50;
+const GET_TIMEOUT_MS = Number(process.env.REDIS_GET_TIMEOUT_MS || 150);
+const SET_TIMEOUT_MS = Number(process.env.REDIS_SET_TIMEOUT_MS || 200);
 const DEFAULT_LOCK_TTL = 60 * 1000;
 
 let redis, redisSubscriber, redlockClient;
+let lastGetTimeoutWarnAt = 0;
+let lastSetTimeoutWarnAt = 0;
 
 async function wait(ms) {
 	return new Promise((resolve, reject) => {
@@ -103,7 +105,18 @@ const redisWrap = {
 				return null;
 			}
 		} catch (e) {
-			logger.error('redis.get failed', e);
+			const isTimeout = String(e?.message || '').includes('Executed timeout');
+			if (isTimeout) {
+				const now = Date.now();
+				if (now - lastGetTimeoutWarnAt > 60 * 1000) {
+					lastGetTimeoutWarnAt = now;
+					logger.warn(
+						`redis.get timed out after ${GET_TIMEOUT_MS}ms, falling back to DB`
+					);
+				}
+			} else {
+				logger.error('redis.get failed', e);
+			}
 
 			return null;
 		}
@@ -120,7 +133,18 @@ const redisWrap = {
 				logger.warn('redis is not initialized');
 			}
 		} catch (e) {
-			logger.error('redis.set failed', e);
+			const isTimeout = String(e?.message || '').includes('Executed timeout');
+			if (isTimeout) {
+				const now = Date.now();
+				if (now - lastSetTimeoutWarnAt > 60 * 1000) {
+					lastSetTimeoutWarnAt = now;
+					logger.warn(
+						`redis.set timed out after ${SET_TIMEOUT_MS}ms, continuing without cache write`
+					);
+				}
+			} else {
+				logger.error('redis.set failed', e);
+			}
 		}
 	},
 

--- a/src/worker/analyzeQueries/index.ts
+++ b/src/worker/analyzeQueries/index.ts
@@ -11,12 +11,14 @@ import schemaModel from '../../database/schema';
 import clientsModel from '../../database/clients';
 import schemaHit from '../../database/schema_hits';
 import operationHit from '../../database/operation_hits';
+import subscriptionMetrics from '../../database/subscription_metrics';
 import persistedQueries from '../../database/persisted_queries';
 
 import extractQueryFields from './extract-query-properties';
 import { connection } from '../../database';
 
 const SCHEMA_UPDATE_PERIOD_MIN = 5;
+const CLIENT_FIELD_MAX_LEN = 50;
 const QUERIES_CHANNEL =
 	process.env.REDIS_QUERIES_CHANNEL ||
 	process.env.KAFKA_QUERIES_TOPIC ||
@@ -59,6 +61,7 @@ const analyzer = {
 
 			schemaHit.init();
 			operationHit.init();
+			subscriptionMetrics.init();
 			clientsModel.init();
 
 			await redis.initRedis();
@@ -127,6 +130,9 @@ const analyzer = {
 					'unknown';
 			}
 
+			name = normalizeClientField(name);
+			version = normalizeClientField(version);
+
 			if (!parsedData.query) {
 				const pq = await persistedQueries.get(persistedQueryHash);
 
@@ -153,6 +159,71 @@ const analyzer = {
 		const msgDate = Number.isFinite(parsedTimestamp)
 			? new Date(parsedTimestamp)
 			: new Date();
+		const hour = `${msgDate.toISOString().slice(0, 13)}:00:00.000Z`;
+		const eventType = String(parsedData.eventType || '');
+
+		if (
+			eventType === 'subscription_start' ||
+			eventType === 'subscription_end'
+		) {
+			const sampleRate = sanitizeSampleRate(parsedData.sampleRate);
+			const sampleMultiplier = 1 / sampleRate;
+			const subscriptionName =
+				String(parsedData.subscriptionName || '').trim() ||
+				getSubscriptionFieldName(
+					parsedData.query || '',
+					parsedData.operationName || null
+				) ||
+				'anonymous';
+
+			if (eventType === 'subscription_start') {
+				await subscriptionMetrics.add({
+					subscriptionName,
+					hour,
+					sampledSessions: 1,
+					estimatedSubscriptions: sampleMultiplier,
+				});
+
+				logger.info('Recorded subscription metric event', {
+					eventType,
+					subscriptionName,
+					hour,
+					sampleRate,
+					estimatedSubscriptions: sampleMultiplier,
+					operationName: parsedData.operationName || null,
+				});
+			}
+
+			if (eventType === 'subscription_end') {
+				const transportedEvents = Number.isFinite(
+					Number(parsedData.transportedEvents)
+				)
+					? Math.max(0, Math.floor(Number(parsedData.transportedEvents)))
+					: 0;
+				const sessionDurationMs = Number.isFinite(
+					Number(parsedData.sessionDurationMs)
+				)
+					? Math.max(0, Math.floor(Number(parsedData.sessionDurationMs)))
+					: 0;
+
+				await subscriptionMetrics.add({
+					subscriptionName,
+					hour,
+					completedSessions: 1,
+					transportedEvents,
+					sessionDurationMs,
+				});
+
+				logger.info('Recorded subscription metric event', {
+					eventType,
+					subscriptionName,
+					hour,
+					transportedEvents,
+					sessionDurationMs,
+					operationName: parsedData.operationName || null,
+				});
+			}
+		}
 
 		if (parsedData.query && schemaHit.allowNewHitWithTime(msgDate)) {
 			logger.info('Processing schema-hit', {
@@ -163,7 +234,6 @@ const analyzer = {
 					parsedData.query,
 					parsedData.operationName
 				);
-				const hour = `${msgDate.toISOString().slice(0, 13)}:00:00.000Z`;
 
 				await operationHit.add({
 					name,
@@ -269,6 +339,70 @@ function getOperationType(query, operationName) {
 	}
 
 	return 'UNKNOWN';
+}
+
+function getSubscriptionFieldName(query, operationName) {
+	try {
+		const parsedQuery = parse(query);
+		const operationDefinition = parsedQuery.definitions.find((definition) => {
+			if (definition.kind !== Kind.OPERATION_DEFINITION) {
+				return false;
+			}
+
+			if (definition.operation !== 'subscription') {
+				return false;
+			}
+
+			if (!operationName) {
+				return true;
+			}
+
+			return definition.name?.value === operationName;
+		});
+
+		if (
+			operationDefinition &&
+			operationDefinition.kind === Kind.OPERATION_DEFINITION
+		) {
+			const selectedField = operationDefinition.selectionSet.selections.find(
+				(selection) => selection.kind === Kind.FIELD
+			);
+
+			if (selectedField && selectedField.kind === Kind.FIELD) {
+				return selectedField.name.value;
+			}
+		}
+	} catch (_) {
+		// ignore parse failures and fallback to operationName
+	}
+
+	return operationName || null;
+}
+
+function sanitizeSampleRate(value) {
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		return 1;
+	}
+
+	return Math.min(1, parsed);
+}
+
+function normalizeClientField(value) {
+	if (isNil(value)) {
+		return value;
+	}
+
+	const normalized = String(value).trim();
+	if (!normalized) {
+		return null;
+	}
+
+	if (normalized.length <= CLIENT_FIELD_MAX_LEN) {
+		return normalized;
+	}
+
+	return normalized.slice(0, CLIENT_FIELD_MAX_LEN);
 }
 
 export default analyzer;


### PR DESCRIPTION
## Summary
- add hourly `subscription_metric_hourly` storage migration
- add subscription metrics model with cache->db sync and retention cleanup
- extend query analyzer worker to ingest `subscription_start` / `subscription_end` events
- normalize client headers to avoid `varchar(50)` insert failures
- add GraphQL query `schemaSubscriptionMetrics`
- add Analytics -> Subscriptions tab with graph and table for estimated subscriptions, avg duration, avg events/session
- tune Redis cache timeout handling/logging to degrade gracefully on timeout

## Validation
- npm run build-backend
- npm run build-frontend
- observed worker logs recording subscription metric events
